### PR TITLE
Depend on hubot only development

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,15 +22,15 @@
   "homepage": "https://github.com/idobata/hubot-idobata",
   "dependencies": {
     "request": "~> 2.34",
-    "pusher-client": "~> 0.2.1",
-    "hubot": "~> 2.7.1"
+    "pusher-client": "~> 0.2.1"
   },
   "devDependencies": {
     "coffee-script": "~> 1.7.1",
     "mocha": "~> 1.17.1",
     "chai": "~> 1.9.0",
     "sinon": "~> 1.8.2",
-    "nock": "~> 0.27.1"
+    "nock": "~> 0.27.1",
+    "hubot": "~> 2.7.1"
   },
   "engines": {
     "node": ">= 0.8"


### PR DESCRIPTION
`npm` loads the different hubot from the following:
- `./node_modules/hubot`
- `./node_modules/hubot-idobata/node_modules/hubot`

This cause instance mismatch using [`instanceof`](https://github.com/github/hubot/blob/v2.7.2/src/listener.coffee#L42)

That's only `./node_modules/hubot` we need.
If `./node_modules/hubot-idobata/node_modules/hubot` is exist,
hubot-idobata wouldn't respond any message.

Fix #1
