### PR TITLE
Fixes error when use `robot.messageRoom` method.

### DIFF
--- a/src/idobata.coffee
+++ b/src/idobata.coffee
@@ -11,7 +11,12 @@ API_TOKEN   = process.env.HUBOT_IDOBATA_API_TOKEN
 
 class Idobata extends Hubot.Adapter
   send: (envelope, strings...) ->
-    @_postMessage string, envelope.message.data.room_id for string in strings
+    room_id = null
+    if envelope.room
+      room_id = envelope.room
+    else
+      room_id = envelope.message.data.room_id
+    @_postMessage string, room_id for string in strings
 
   reply: (envelope, strings...) ->
     strings = strings.map (string) -> "@#{envelope.user.name} #{string}"


### PR DESCRIPTION
Errors occurred when use `robot.messageRoom` method in my script.
So, fix it.

My bot script:

``` coffee
module.exports = (robot) ->
  robot.router.get '/send/:room', (req, res) ->
    room   = req.params.room
    message = req.query.message
    robot.messageRoom room, message

    res.contentType 'application/json'
    res.send JSON.stringify({'stataus' : 'success', 'room' : room, 'message' : message})
```

Errors are:

```
TypeError: Cannot read property 'data' of undefined
  at Idobata.send (/home/***/idobata/node_modules/hubot-idobata/src/idobata.coffee:14:5, <js>:37:65)
  at Robot.messageRoom (/home/***/idobata/node_modules/hubot/src/robot.coffee:409:19, <js>:382:42)
  at module.exports (/home/***/scripts/myscript.coffee:40:5, <js>:19:13)
  at callbacks (/home/***/idobata/node_modules/hubot/node_modules/express/lib/router/index.js:161:37)
  at param (/home/***/idobata/node_modules/hubot/node_modules/express/lib/router/index.js:135:11)
  at param (/home/***/idobata/node_modules/hubot/node_modules/express/lib/router/index.js:132:11)
  at pass (/home/***/idobata/node_modules/hubot/node_modules/express/lib/router/index.js:142:5)
  at Router._dispatch (/home/***/idobata/node_modules/hubot/node_modules/express/lib/router/index.js:170:5)
  at Object.router (/home/***/idobata/node_modules/hubot/node_modules/express/lib/router/index.js:33:10)
  at next (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/proto.js:190:15)
  at multipart (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/middleware/multipart.js:64:37)
  at module.exports (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/middleware/bodyParser.js:57:9)
  at urlencoded (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/middleware/urlencoded.js:51:37)
  at module.exports (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/middleware/bodyParser.js:55:7)
  at json (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/middleware/json.js:53:37)
  at Object.bodyParser [as handle] (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/middleware/bodyParser.js:53:5)
  at next (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/proto.js:190:15)
  at Object.query [as handle] (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/middleware/query.js:44:5)
  at next (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/proto.js:190:15)
  at Object.handle (/home/***/idobata/node_modules/hubot/src/robot.coffee:278:7, <js>:236:16)
  at next (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/proto.js:190:15)
  at Object.expressInit [as handle] (/home/***/idobata/node_modules/hubot/node_modules/express/lib/middleware.js:30:5)
  at next (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/proto.js:190:15)
  at Object.query [as handle] (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/middleware/query.js:44:5)
  at next (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/proto.js:190:15)
  at Function.app.handle (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/proto.js:198:3)
  at Server.app (/home/***/idobata/node_modules/hubot/node_modules/express/node_modules/connect/lib/connect.js:65:37)
  at Server.EventEmitter.emit (events.js:99:17)
  at HTTPParser.parser.onIncoming (http.js:1968:12)
  at HTTPParser.parserOnHeadersComplete [as onHeadersComplete] (http.js:111:23)
  at Socket.socket.ondata (http.js:1832:22)
  at TCP.onread (net.js:404:27)
```
