### PR TITLE
Fix doc: using yo to create hubot

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ Idobata adapter for GitHub's Hubot
 
 1. Install dependency modules:
   ``` sh
-  $ npm install --global coffee-script hubot
+  $ npm install --global coffee-script hubot generator-hubot
   ```
 
 2. Create a new hubot:
   ``` sh
-  $ hubot --create <path>
+  $ mkdir <path>
   $ cd <path>
+  $ yo hubot
   ```
 
 3. Install the [hubot-idobata][]:


### PR DESCRIPTION
now `hubot --create` is deprecated:

```
$ hubot --create
'hubot --create' is depreated. Use the yeoman generator instead:
    npm install -g generator-hubot
    mkdir yourbot
    yo hubot
See https://github.com/github/hubot/blob/master/docs/README.md for more details on getting started.
```

~~I tried above message, but couldn't.~~
~~Instead, installing `generator-hubot-bot` and `yo hubot-bot` is good in my environment, so i wrote them to README.md.~~

update:
i tried above once more time, `yo hubot` was working completely :bow: 
so i amended the commit to use one.

thanks.
