### PR TITLE
Use SVG image format on Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hubot-idobata
 
-[![Build Status](https://travis-ci.org/idobata/hubot-idobata.png)](https://travis-ci.org/idobata/hubot-idobata)
+[![Build Status](https://travis-ci.org/idobata/hubot-idobata.svg)](https://travis-ci.org/idobata/hubot-idobata)
 
 Idobata adapter for GitHub's Hubot
 


### PR DESCRIPTION
I think that SVG format is more clear than PNG format.